### PR TITLE
rel: 0.8.1; Force checkout head for Fast-Forward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 05-30-2024
+- Force checkout when using Fast-Forward when updating git `crates.io-index`
+
 ## [0.8.0] - 05-29-2024
 - Properly set local HEAD to fetched git repo `crates.io-index` when updating from previous zerus invocation
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,7 +1542,7 @@ checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
 name = "zerus"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zerus"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 authors = ["wcampbell"]
 description = "Lightweight binary to download only project required crates for offline crates.io mirror"

--- a/src/git.rs
+++ b/src/git.rs
@@ -232,6 +232,6 @@ fn fast_forward(
     println!("{}", msg);
     lb.set_target(rc.id(), &msg)?;
     repo.set_head(&name)?;
-    repo.checkout_head(None)?;
+    repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))?;
     Ok(())
 }


### PR DESCRIPTION
- This is needed to keep the crates.io up to date when updating from previous session